### PR TITLE
Feature/3-get current server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Bungeecord-Expansion
+
 Expansion for bungeecord placeholders
 [![Build Status](http://ci.extendedclip.com/buildStatus/icon?job=Bungeecord-Expansion)](http://ci.extendedclip.com/job/Bungeecord-Expansion/)

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.6</version>
+            <version>2.11.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.extendedclip.papi.bungeeexpansion</groupId>
     <artifactId>bungee-expansion</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 
     <name>PAPI-Expansion-Bungee</name>
     <description>PlaceholderAPI expansion for bungeecord placeholders</description>
@@ -58,5 +58,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
Updates dependencies, implements #3.

Existing placeholders remapped:
`%bungee_total%`: `%bungee_count_total%`
`%bungee_<servername>%`: `%bungee_count_<servername>%`

New placeholders created:
`%bungee_count%`: The player count for the current server (via BungeeCord)
`%bungee_server_name%`: The current server's name, as defined in BungeeCord's config.yml

Bumped version to 3.0 due to breaking changes in existing placeholders.