### PR TITLE
Update PlaceholderAPI Version and Add Server Status Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.6</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/extendedclip/papi/bungeeexpansion/BungeeExpansion.java
+++ b/src/main/java/com/extendedclip/papi/bungeeexpansion/BungeeExpansion.java
@@ -73,6 +73,11 @@ public final class BungeeExpansion extends PlaceholderExpansion implements Plugi
     public String onRequest(final OfflinePlayer player, String identifier) {
         final int value;
 
+        if (identifier.startsWith("online_")) {
+            final String server = identifier.substring(7).toLowerCase();
+            return counts.containsKey(server) ? "§aOnline" : "§cOffline";
+        }
+
         switch (identifier.toLowerCase()) {
             case "all":
             case "total":

--- a/src/main/java/com/extendedclip/papi/bungeeexpansion/BungeeExpansion.java
+++ b/src/main/java/com/extendedclip/papi/bungeeexpansion/BungeeExpansion.java
@@ -63,12 +63,16 @@ public final class BungeeExpansion extends PlaceholderExpansion implements Plugi
 
     @Override
     public String getVersion() {
-        return "2.3";
+        return "2.4";
     }
 
     @Override
     public Map<String, Object> getDefaults() {
-        return Collections.singletonMap(CONFIG_INTERVAL, 30);
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put(CONFIG_INTERVAL, 30);
+        defaults.put("online", "Online");
+        defaults.put("offline", "Offline");
+        return defaults;
     }
 
 
@@ -96,10 +100,8 @@ public final class BungeeExpansion extends PlaceholderExpansion implements Plugi
 
     @Override
     public void start() {
-        if (hasString("online"))
-            this.online = getString("online", "Online");
-        if (hasString("offline"))
-            this.offline = getString("offline", "Offline");
+        this.online = getString("online", "Online");
+        this.offline = getString("offline", "Offline");
 
         final BukkitTask task = Bukkit.getScheduler().runTaskTimer(getPlaceholderAPI(), () -> {
 
@@ -119,13 +121,6 @@ public final class BungeeExpansion extends PlaceholderExpansion implements Plugi
             Bukkit.getMessenger().registerOutgoingPluginChannel(getPlaceholderAPI(), MESSAGE_CHANNEL);
             Bukkit.getMessenger().registerIncomingPluginChannel(getPlaceholderAPI(), MESSAGE_CHANNEL, this);
         }
-    }
-
-    private boolean hasString(String path) {
-        ConfigurationSection section = this.getConfigSection();
-        if (section == null)
-            return false;
-        return section.contains(path);
     }
 
     @Override


### PR DESCRIPTION
This pull request includes the following updates:
1. **Version Update**: The `PlaceholderAPI` dependency has been updated from version `2.10.6` to `2.11.6` in the `pom.xml` file. This ensures compatibility with the latest features and bug fixes provided by the new version of the API.
2. **New Feature**: Added functionality to check if a specific server is online in the `onRequest` method. If the identifier starts with `online_`, the system now verifies the server's status and returns `§aOnline` if the server is available or `§cOffline` if it is not.

This update improves compatibility and adds a new feature for checking server statuses dynamically based on the identifier provided.